### PR TITLE
Fix CocoaPods wrong podspec path, result modular headers errors

### DIFF
--- a/libheif.podspec
+++ b/libheif.podspec
@@ -34,7 +34,7 @@ HEIF is a new image file format employing HEVC (h.265) image coding for the best
   s.subspec 'libheif' do |ss|
     ss.source_files = 'libheif/**/*.{h,c,cc}'
     ss.exclude_files = 'libheif/plugins/decoder_libde265.{h,c,cc}', 'libheif/plugins/encoder_x265.{h,c,cc}', 'libheif/plugins/encoder_aom.{h,c,cc}', 'libheif/plugins/decoder_aom.{h,c,cc}', 'libheif/plugins/decoder_dav1d.{h,c,cc}', 'libheif/plugins/encoder_rav1e.{h,c,cc}', 'libheif/plugins/encoder_svt.{h,c,cc}', 'libheif/plugins_windows.{h,c,cc}', 'libheif/plugins_unix.{h,c,cc}'
-    ss.public_header_files = 'libheif/heif.h', 'libheif/plugins/heif_version.h'
+    ss.public_header_files = 'libheif/heif.h', 'libheif/heif_version.h'
     ss.preserve_path = 'libheif'
     ss.xcconfig = {
       'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) HAVE_UNISTD_H=1',


### PR DESCRIPTION
The public headers does not get correct set.

The old version from 1.15-1.16+ all get effected by this. But I only decide to release another new v1.16.2 version.


![image](https://github.com/SDWebImage/libheif-Xcode/assets/6919743/bf4f3e49-b5eb-4db5-b4c8-5641e3a89012)
![image](https://github.com/SDWebImage/libheif-Xcode/assets/6919743/7be83f7d-3468-4a4e-8e33-c75503c985a6)
