### PR TITLE
Fix another issue during the modular_headers integration on CocoaPods

### DIFF
--- a/libheif.podspec
+++ b/libheif.podspec
@@ -64,6 +64,7 @@ HEIF is a new image file format employing HEVC (h.265) image coding for the best
     ss.preserve_path = 'libheif'
     ss.xcconfig = {
       'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) HAVE_X265=1',
+      'WARNING_CFLAGS' => '$(inherited) Wno-module-import-in-extern-c' # import of C++ module 'libx265' appears within extern "C" language linkage specification
       'HEADER_SEARCH_PATHS' => '$(inherited) ${PODS_ROOT}/libheif/ ${PODS_TARGET_SRCROOT}/ ${PODS_ROOT}/libx265/source/' # Fix #include <x265.h>
     }
   end


### PR DESCRIPTION
![image](https://github.com/SDWebImage/libheif-Xcode/assets/6919743/a8f34e18-37e8-4571-80d5-9dbaa5819a36)


Seems clang defaults treat this warning as error, which because of the language spec for C++/C which is conflict with clang module:

See: https://forums.swift.org/t/import-of-c-module-appears-within-extern-c-language-linkage-specification/65606/2